### PR TITLE
Crystal 1.19.0 compatibility

### DIFF
--- a/benchmarks/bench_parser_single.cr
+++ b/benchmarks/bench_parser_single.cr
@@ -22,11 +22,11 @@ end
 times = [] of Float64
 program = nil
 10.times do
-  start = Time.monotonic
+  start = Time.instant
   lexer = Lexer.new(content)
   parser = Parser.new(lexer)
   program = parser.parse_program
-  time = (Time.monotonic - start).total_milliseconds
+  time = (Time.instant - start).total_milliseconds
   times << time
 end
 

--- a/benchmarks/bench_prelude.cr
+++ b/benchmarks/bench_prelude.cr
@@ -15,9 +15,9 @@ puts ""
 # Sequential
 puts "Sequential loading..."
 loader_seq = FileLoader.new(search_paths, parallel: false)
-start = Time.monotonic
+start = Time.instant
 program_seq = loader_seq.load_with_requires(PRELUDE_ENTRY)
-time_seq = (Time.monotonic - start).total_milliseconds
+time_seq = (Time.instant - start).total_milliseconds
 stats_seq = loader_seq.stats
 
 puts "  Time:  #{time_seq.round(2)} ms"
@@ -28,9 +28,9 @@ puts ""
 # Parallel
 puts "Parallel loading..."
 loader_par = FileLoader.new(search_paths, parallel: true)
-start = Time.monotonic
+start = Time.instant
 program_par = loader_par.load_with_requires(PRELUDE_ENTRY)
-time_par = (Time.monotonic - start).total_milliseconds
+time_par = (Time.instant - start).total_milliseconds
 stats_par = loader_par.stats
 
 puts "  Time:  #{time_par.round(2)} ms"

--- a/benchmarks/compare_formatters.cr
+++ b/benchmarks/compare_formatters.cr
@@ -13,9 +13,9 @@ puts ""
 puts "=== Original Crystal Formatter ==="
 times = [] of Float64
 10.times do |i|
-  start = Time.monotonic
+  start = Time.instant
   formatted = Crystal.format(source)
-  elapsed = Time.monotonic - start
+  elapsed = Time.instant - start
   times << elapsed.total_milliseconds
   print "." if i % 2 == 0
 end

--- a/benchmarks/compare_formatters_v2.cr
+++ b/benchmarks/compare_formatters_v2.cr
@@ -12,9 +12,9 @@ puts ""
 puts "=== CrystalV2 Token-based Formatter ==="
 times = [] of Float64
 10.times do |i|
-  start = Time.monotonic
+  start = Time.instant
   formatted = CrystalV2::Compiler::Formatter.format(source)
-  elapsed = Time.monotonic - start
+  elapsed = Time.instant - start
   times << elapsed.total_milliseconds
   print "." if i % 2 == 0
 end

--- a/benchmarks/compare_parsers.cr
+++ b/benchmarks/compare_parsers.cr
@@ -25,29 +25,29 @@ end
 def benchmark_v2_single_file(path : String) : {Time::Span, Int32, Int32}
   source = File.read(path)
 
-  start = Time.monotonic
+  start = Time.instant
   lexer = CrystalV2::Compiler::Frontend::Lexer.new(source)
   parser = CrystalV2::Compiler::Frontend::Parser.new(lexer)
   program = parser.parse_program
-  duration = Time.monotonic - start
+  duration = Time.instant - start
 
   {duration, program.roots.size, parser.diagnostics.size}
 end
 
 def benchmark_v2_multi_file(entry_path : String) : {Time::Span, Int32, Int32}
-  start = Time.monotonic
+  start = Time.instant
   loader = CrystalV2::Compiler::FileLoader.new
   program = loader.load_with_requires(entry_path)
-  duration = Time.monotonic - start
+  duration = Time.instant - start
 
   stats = loader.stats
   {duration, stats[:files_loaded], stats[:total_nodes]}
 end
 
 def benchmark_original_crystal(path : String) : {Time::Span, String}
-  start = Time.monotonic
+  start = Time.instant
   output = `crystal build --no-codegen "#{path}" 2>&1`
-  duration = Time.monotonic - start
+  duration = Time.instant - start
 
   {duration, output}
 end

--- a/benchmarks/lsp_harness.cr
+++ b/benchmarks/lsp_harness.cr
@@ -480,9 +480,9 @@ module CrystalV2
           end
 
           send_payload(payload)
-          started = Time.monotonic
+          started = Time.instant
           response = await_response(id)
-          elapsed = Time.monotonic - started
+          elapsed = Time.instant - started
           {response, elapsed.total_milliseconds}
         end
 

--- a/benchmarks/parser_benchmark.cr
+++ b/benchmarks/parser_benchmark.cr
@@ -16,7 +16,7 @@ total_files = 0
 total_lines = 0
 total_nodes = 0
 failed_files = 0
-start_time = Time.monotonic
+start_time = Time.instant
 
 files.each do |file_path|
   next unless File.exists?(file_path)
@@ -41,7 +41,7 @@ files.each do |file_path|
   end
 end
 
-end_time = Time.monotonic
+end_time = Time.instant
 elapsed = (end_time - start_time).total_seconds
 
 puts

--- a/benchmarks/prelude_full.cr
+++ b/benchmarks/prelude_full.cr
@@ -1,7 +1,7 @@
 require "../src/compiler/lsp/server"
 
 puts "Full prelude load (with name resolution)..."
-start = Time.monotonic
+start = Time.instant
 
 server = CrystalV2::Compiler::LSP::Server.new(
   STDIN,
@@ -12,5 +12,5 @@ server = CrystalV2::Compiler::LSP::Server.new(
   )
 )
 
-elapsed = Time.monotonic - start
+elapsed = Time.instant - start
 puts "Prelude load time (symbol_only=false): #{elapsed.total_milliseconds.round(2)}ms"

--- a/collab_logs/20251125-213925-gpt5.md
+++ b/collab_logs/20251125-213925-gpt5.md
@@ -7,7 +7,7 @@ Timestamp: $(date -Iseconds)
 - Local user file to ignore: .claude/settings.local.json.
 
 ## LSP tests
-- Ran `CRYSTAL_CACHE_DIR=/tmp/crystal_cache ./tools/lsp_tests.py` -> PASS (diagnostics empty; hover Time.monotonic; definition Time/JSON/OptionParser resolved to stdlib).
+- Ran `CRYSTAL_CACHE_DIR=/tmp/crystal_cache ./tools/lsp_tests.py` -> PASS (diagnostics empty; hover Time.instant; definition Time/JSON/OptionParser resolved to stdlib).
 
 ## Recent changes summary (from history)
 - Prelude symbol-only path available (ServerConfig#prelude_symbol_only or env LSP_PRELUDE_SYMBOL_ONLY=1).

--- a/src/compiler/driver.cr
+++ b/src/compiler/driver.cr
@@ -198,7 +198,7 @@ module Crystal::V2
       debug_hir_timings = ENV.has_key?("DEBUG_HIR_TIMINGS")
 
       flags = CrystalV2::Runtime.target_flags
-      collect_start = Time.monotonic if debug_hir_timings
+      collect_start = Time.instant if debug_hir_timings
       all_arenas.each do |arena, exprs, file_path, source|
         pending_annotations = [] of Tuple(CrystalV2::Compiler::Frontend::AnnotationNode, CrystalV2::Compiler::Frontend::ArenaLike)
         exprs.each do |expr_id|
@@ -223,7 +223,7 @@ module Crystal::V2
           end
         end
       if debug_hir_timings && collect_start
-        elapsed = (Time.monotonic - collect_start).total_milliseconds
+        elapsed = (Time.instant - collect_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] collect_top_level_nodes #{elapsed.round(1)}ms"
       end
 
@@ -243,7 +243,7 @@ module Crystal::V2
 
       # Three-pass approach:
       # Pass 1: Register all enums, modules, class types and their methods
-      pass1_start = Time.monotonic if debug_hir_timings
+      pass1_start = Time.instant if debug_hir_timings
       if ENV.has_key?("DEBUG_NESTED_CLASS")
         STDERR.puts "[DEBUG_DRIVER] class_nodes: #{class_nodes.size}, module_nodes: #{module_nodes.size}"
         module_nodes.each do |module_node, arena|
@@ -289,7 +289,7 @@ module Crystal::V2
         hir_converter.register_class(class_node)
       end
       if debug_hir_timings && pass1_start
-        elapsed = (Time.monotonic - pass1_start).total_milliseconds
+        elapsed = (Time.instant - pass1_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] register_types #{elapsed.round(1)}ms"
       end
 
@@ -309,10 +309,10 @@ module Crystal::V2
 
       # Flush pending monomorphizations now that all templates are registered
       puts "  Flushing pending monomorphizations..." if @verbose
-      mono_start = Time.monotonic if debug_hir_timings
+      mono_start = Time.instant if debug_hir_timings
       hir_converter.flush_pending_monomorphizations
       if debug_hir_timings && mono_start
-        elapsed = (Time.monotonic - mono_start).total_milliseconds
+        elapsed = (Time.instant - mono_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] flush_pending_monomorphizations #{elapsed.round(1)}ms"
       end
 
@@ -320,27 +320,27 @@ module Crystal::V2
       hir_converter.refresh_union_descriptors
 
       # Pass 2: Register all top-level function signatures
-      pass2_start = Time.monotonic if debug_hir_timings
+      pass2_start = Time.instant if debug_hir_timings
       def_nodes.each do |node, arena|
         hir_converter.arena = arena
         hir_converter.register_function(node)
       end
       if debug_hir_timings && pass2_start
-        elapsed = (Time.monotonic - pass2_start).total_milliseconds
+        elapsed = (Time.instant - pass2_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] register_functions #{elapsed.round(1)}ms"
       end
 
       # Pass 3: Lower all function and method bodies
       func_count = 0
-      pass3_start = Time.monotonic if debug_hir_timings
+      pass3_start = Time.instant if debug_hir_timings
       slow_ms = ENV["DEBUG_HIR_SLOW_MS"]?.try(&.to_f)
       unless ENV.has_key?("CRYSTAL_V2_LAZY_HIR")
         module_nodes.each do |module_node, arena|
           hir_converter.arena = arena
           if slow_ms
-            start = Time.monotonic
+            start = Time.instant
             hir_converter.lower_module(module_node)
-            elapsed = (Time.monotonic - start).total_milliseconds
+            elapsed = (Time.instant - start).total_milliseconds
             if elapsed >= slow_ms
               name = String.new(module_node.name)
               source_path = paths_by_arena[arena]?
@@ -354,9 +354,9 @@ module Crystal::V2
         class_nodes.each do |class_node, arena|
           hir_converter.arena = arena
           if slow_ms
-            start = Time.monotonic
+            start = Time.instant
             hir_converter.lower_class(class_node)
-            elapsed = (Time.monotonic - start).total_milliseconds
+            elapsed = (Time.instant - start).total_milliseconds
             if elapsed >= slow_ms
               name = String.new(class_node.name)
               source_path = paths_by_arena[arena]?
@@ -371,13 +371,13 @@ module Crystal::V2
         trace_driver("[DRIVER_TRACE] CRYSTAL_V2_LAZY_HIR=1; skipping eager module/class lowering")
       end
       if debug_hir_timings && pass3_start
-        elapsed = (Time.monotonic - pass3_start).total_milliseconds
+        elapsed = (Time.instant - pass3_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] lower_modules_classes #{elapsed.round(1)}ms"
       end
 
       # Create synthetic main function from top-level expressions (or user-defined main)
       STDERR.puts "[HIR_TIMING] start lower_main" if debug_hir_timings
-      main_start = Time.monotonic if debug_hir_timings
+      main_start = Time.instant if debug_hir_timings
       if main_exprs.size > 0
         hir_converter.lower_main(main_exprs)
         func_count += 1
@@ -387,33 +387,33 @@ module Crystal::V2
         func_count += 1
       end
       if debug_hir_timings && main_start
-        elapsed = (Time.monotonic - main_start).total_milliseconds
+        elapsed = (Time.instant - main_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] lower_main #{elapsed.round(1)}ms"
       end
 
       # Ensure top-level `fun main` is lowered as an entrypoint when present.
       STDERR.puts "[HIR_TIMING] start lower_fun_main" if debug_hir_timings
-      fun_main_start = Time.monotonic if debug_hir_timings
+      fun_main_start = Time.instant if debug_hir_timings
       if fun_main = def_nodes.find { |(n, _)| n.receiver.try { |recv| String.new(recv) == HIR::AstToHir::FUN_DEF_RECEIVER } || false }
         hir_converter.arena = fun_main[1]
         hir_converter.lower_def(fun_main[0])
         func_count += 1
       end
       if debug_hir_timings && fun_main_start
-        elapsed = (Time.monotonic - fun_main_start).total_milliseconds
+        elapsed = (Time.instant - fun_main_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] lower_fun_main #{elapsed.round(1)}ms"
       end
 
       # Lower remaining top-level function bodies after main to allow
       # call-site types to guide inference for used functions.
       STDERR.puts "[HIR_TIMING] start lower_defs" if debug_hir_timings
-      defs_start = Time.monotonic if debug_hir_timings
+      defs_start = Time.instant if debug_hir_timings
       def_nodes.each do |node, arena|
         hir_converter.arena = arena
         if slow_ms
-          start = Time.monotonic
+          start = Time.instant
           hir_converter.lower_def(node)
-          elapsed = (Time.monotonic - start).total_milliseconds
+          elapsed = (Time.instant - start).total_milliseconds
           if elapsed >= slow_ms
             name = String.new(node.name)
             source_path = paths_by_arena[arena]?
@@ -425,7 +425,7 @@ module Crystal::V2
         func_count += 1
       end
       if debug_hir_timings && defs_start
-        elapsed = (Time.monotonic - defs_start).total_milliseconds
+        elapsed = (Time.instant - defs_start).total_milliseconds
         STDERR.puts "[HIR_TIMING] lower_defs #{elapsed.round(1)}ms"
       end
 

--- a/src/compiler/frontend/watchdog.cr
+++ b/src/compiler/frontend/watchdog.cr
@@ -9,12 +9,12 @@ module CrystalV2
 
         class TimeoutError < Exception; end
 
-        @@deadline : Time::Span? = nil
+        @@deadline : Time::Instant? = nil
         @@message = "watchdog abort"
 
         def self.enable!(message = "watchdog abort", timeout : Time::Span = 30.seconds)
           @@message = message
-          @@deadline = Time.monotonic + timeout
+          @@deadline = Time.instant + timeout
         end
 
         def self.disable!
@@ -23,7 +23,7 @@ module CrystalV2
 
         def self.abort!(message = @@message)
           @@message = message
-          @@deadline = Time.monotonic  # force immediate timeout
+          @@deadline = Time.instant  # force immediate timeout
         end
 
         def self.enabled?
@@ -34,7 +34,7 @@ module CrystalV2
           # Fast path: if no deadline, skip entirely
           return unless (dl = @@deadline)
           # Raise when current time exceeds deadline
-          raise TimeoutError.new(@@message) if Time.monotonic >= dl
+          raise TimeoutError.new(@@message) if Time.instant >= dl
         end
       end
     end

--- a/src/compiler/lsp/debouncer.cr
+++ b/src/compiler/lsp/debouncer.cr
@@ -13,7 +13,7 @@ module CrystalV2
         getter version : Int32
         getter timestamp : Time
 
-        def initialize(@uri, @text, @version, @timestamp = Time.monotonic)
+        def initialize(@uri, @text, @version, @timestamp = Time.instant)
         end
       end
 
@@ -65,7 +65,7 @@ module CrystalV2
         # Process a specific URI immediately (bypassing debounce)
         def process_now(uri : String, text : String, version : Int32)
           @pending.delete(uri)
-          @last_process_time[uri] = Time.monotonic
+          @last_process_time[uri] = Time.instant
           @process_callback.try &.call(uri, text, version)
         end
 
@@ -100,7 +100,7 @@ module CrystalV2
         end
 
         private def process_ready_changes
-          now = Time.monotonic
+          now = Time.instant
           ready_uris = [] of String
 
           @pending.each do |uri, change|
@@ -120,7 +120,7 @@ module CrystalV2
 
         private def process_all_pending
           @pending.each do |uri, change|
-            @last_process_time[uri] = Time.monotonic
+            @last_process_time[uri] = Time.instant
             @process_callback.try &.call(change.uri, change.text, change.version)
           end
           @pending.clear
@@ -141,13 +141,13 @@ module CrystalV2
           last = @last_run[key]?
           return true unless last
 
-          elapsed = (Time.monotonic - last).total_milliseconds
+          elapsed = (Time.instant - last).total_milliseconds
           elapsed >= @interval_ms
         end
 
         # Mark operation as run
         def mark_run(key : String)
-          @last_run[key] = Time.monotonic
+          @last_run[key] = Time.instant
         end
 
         # Run operation if throttle allows

--- a/src/compiler/lsp/unified_project.cr
+++ b/src/compiler/lsp/unified_project.cr
@@ -697,16 +697,16 @@ module CrystalV2
           version : Int32 = 0,
         ) : Array(Diagnostic)
           # Phase 1: Parse the file
-          parse_start = Time.monotonic
+          parse_start = Time.instant
           lexer = Frontend::Lexer.new(source)
           file_arena = Frontend::AstArena.new
           parser = Frontend::Parser.new(lexer, file_arena)
           program = parser.parse_program
 
-          parse_time = Time.monotonic - parse_start
+          parse_time = Time.instant - parse_start
 
           # Phase 2: Update arena
-          arena_start = Time.monotonic
+          arena_start = Time.instant
           if @files.has_key?(path)
             # Replace existing file's arena
             @arena.replace_file_arena(path, file_arena)
@@ -716,22 +716,22 @@ module CrystalV2
             @arena.add_file_arena(path, file_arena)
             @file_order << path
           end
-          arena_time = Time.monotonic - arena_start
+          arena_time = Time.instant - arena_start
 
           # Phase 3: Collect symbols from this file
-          symbol_start = Time.monotonic
+          symbol_start = Time.instant
           file_symbols = collect_file_symbols(program, path)
-          symbol_time = Time.monotonic - symbol_start
+          symbol_time = Time.instant - symbol_start
 
           # Phase 4: Run semantic analysis on this file (updates type_context)
-          semantic_start = Time.monotonic
+          semantic_start = Time.instant
           diagnostics = analyze_file_semantics(program, path, file_symbols)
-          semantic_time = Time.monotonic - semantic_start
+          semantic_time = Time.instant - semantic_start
 
           # Phase 5: Build symbol summaries with inferred types (after inference)
-          summaries_start = Time.monotonic
+          summaries_start = Time.instant
           symbol_summaries = build_symbol_summaries(file_symbols, program, @type_context)
-          summaries_time = Time.monotonic - summaries_start
+          summaries_time = Time.instant - summaries_start
 
           # Phase 6: Update file state
           requires = collect_requires(program, path)

--- a/src/stdlib/benchmark.cr
+++ b/src/stdlib/benchmark.cr
@@ -131,9 +131,9 @@ module Benchmark
 
   # Returns the time used to execute the given block.
   def measure(label = "", &) : BM::Tms
-    t0, r0 = Process.times, Time.monotonic
+    t0, r0 = Process.times, Time.instant
     yield
-    t1, r1 = Process.times, Time.monotonic
+    t1, r1 = Process.times, Time.instant
     BM::Tms.new(t1.utime - t0.utime,
       t1.stime - t0.stime,
       t1.cutime - t0.cutime,

--- a/src/stdlib/benchmark/ips.cr
+++ b/src/stdlib/benchmark/ips.cr
@@ -67,9 +67,9 @@ module Benchmark
 
           count = 0_u64
           elapsed = Time.measure do
-            target = Time.monotonic + @warmup_time
+            target = Time.instant + @warmup_time
 
-            while Time.monotonic < target
+            while Time.instant < target
               item.call
               count += 1
             end
@@ -87,7 +87,7 @@ module Benchmark
           bytes = 0_i64
           cycles = 0_i64
 
-          target = Time.monotonic + @calculation_time
+          target = Time.instant + @calculation_time
 
           loop do
             elapsed = nil
@@ -97,7 +97,7 @@ module Benchmark
             bytes += bytes_taken
             cycles += item.cycles
             measurements << elapsed.not_nil!
-            break if Time.monotonic >= target
+            break if Time.instant >= target
           end
 
           ips = measurements.map { |m| item.cycles.to_f / m.total_seconds }

--- a/src/stdlib/crystal/event_loop/iocp.cr
+++ b/src/stdlib/crystal/event_loop/iocp.cr
@@ -97,7 +97,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
       if time = @mutex.synchronize { @timers.next_ready? }
         # convert absolute time of next timer to relative time, expressed in
         # milliseconds, rounded up
-        seconds, nanoseconds = System::Time.monotonic
+        seconds, nanoseconds = System::Time.instant
         relative = time - Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
         timeout = (relative.to_i * 1000 + (relative.nanoseconds + 999_999) // 1_000_000).clamp(0_i64..)
       else

--- a/src/stdlib/crystal/event_loop/iocp/fiber_event.cr
+++ b/src/stdlib/crystal/event_loop/iocp/fiber_event.cr
@@ -9,7 +9,7 @@ class Crystal::EventLoop::IOCP::FiberEvent
 
   # io timeout, sleep, or select timeout
   def add(timeout : Time::Span) : Nil
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     @timer.wake_at = now + timeout
     EventLoop.current.add_timer(pointerof(@timer))

--- a/src/stdlib/crystal/event_loop/iocp/timer.cr
+++ b/src/stdlib/crystal/event_loop/iocp/timer.cr
@@ -27,7 +27,7 @@ struct Crystal::EventLoop::IOCP::Timer
 
   def initialize(@type : Type, @fiber, timeout : Time::Span? = nil)
     if timeout
-      seconds, nanoseconds = System::Time.monotonic
+      seconds, nanoseconds = System::Time.instant
       now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
       @wake_at = now + timeout
     end

--- a/src/stdlib/crystal/event_loop/kqueue.cr
+++ b/src/stdlib/crystal/event_loop/kqueue.cr
@@ -216,7 +216,7 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
     if time
       flags = LibC::EV_ADD | LibC::EV_ONESHOT | LibC::EV_CLEAR
 
-      seconds, nanoseconds = System::Time.monotonic
+      seconds, nanoseconds = System::Time.instant
       now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
       t = time - now
 

--- a/src/stdlib/crystal/event_loop/polling/event.cr
+++ b/src/stdlib/crystal/event_loop/polling/event.cr
@@ -41,7 +41,7 @@ struct Crystal::EventLoop::Polling::Event
 
   def initialize(@type : Type, @fiber, @index = nil, timeout : Time::Span? = nil)
     if timeout
-      seconds, nanoseconds = System::Time.monotonic
+      seconds, nanoseconds = System::Time.instant
       now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
       @wake_at = now + timeout
     end

--- a/src/stdlib/crystal/event_loop/polling/fiber_event.cr
+++ b/src/stdlib/crystal/event_loop/polling/fiber_event.cr
@@ -7,7 +7,7 @@ class Crystal::EventLoop::Polling::FiberEvent
 
   # sleep or select timeout
   def add(timeout : Time::Span) : Nil
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     @event.wake_at = now + timeout
     EventLoop.current.add_timer(pointerof(@event))

--- a/src/stdlib/crystal/event_loop/timers.cr
+++ b/src/stdlib/crystal/event_loop/timers.cr
@@ -26,10 +26,10 @@ struct Crystal::EventLoop::Timers(T)
   end
 
   # Dequeues and yields each ready timer (their `#wake_at` is lower than
-  # `System::Time.monotonic`) from the oldest to the most recent (i.e. time
+  # `System::Time.instant`) from the oldest to the most recent (i.e. time
   # ascending).
   def dequeue_ready(& : Pointer(T) -> Nil) : Nil
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
 
     while event = @heap.first?

--- a/src/stdlib/crystal/system/win32/waitable_timer.cr
+++ b/src/stdlib/crystal/system/win32/waitable_timer.cr
@@ -15,7 +15,7 @@ class Crystal::System::WaitableTimer
   def set(time : ::Time::Span) : Nil
     # convert absolute time to relative time, expressed in 100ns interval,
     # rounded up
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     relative = time - ::Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     ticks = (relative.to_i * 10_000_000 + (relative.nanoseconds + 99) // 100).clamp(0_i64..)
 

--- a/src/stdlib/fiber/execution_context/monitor.cr
+++ b/src/stdlib/fiber/execution_context/monitor.cr
@@ -47,9 +47,9 @@ module Fiber::ExecutionContext
 
       loop do
         Thread.sleep(remaining)
-        now = Time.monotonic
+        now = Time.instant
         yield(now)
-        remaining = (now + @every - Time.monotonic).clamp(Time::Span.zero..)
+        remaining = (now + @every - Time.instant).clamp(Time::Span.zero..)
       rescue exception
         Crystal.print_error_buffered("BUG: %s#every crashed", self.class.name, exception: exception)
       end

--- a/src/stdlib/http/server/handlers/log_handler.cr
+++ b/src/stdlib/http/server/handlers/log_handler.cr
@@ -11,12 +11,12 @@ class HTTP::LogHandler
   end
 
   def call(context : HTTP::Server::Context) : Nil
-    start = Time.monotonic
+    start = Time.instant
 
     begin
       call_next(context)
     ensure
-      elapsed = Time.monotonic - start
+      elapsed = Time.instant - start
       elapsed_text = elapsed_text(elapsed)
 
       req = context.request

--- a/src/stdlib/spec/dsl.cr
+++ b/src/stdlib/spec/dsl.cr
@@ -181,7 +181,7 @@ module Spec
     @start_time : Time::Span? = nil
 
     def run
-      @start_time = Time.monotonic
+      @start_time = Time.instant
 
       at_exit do |status|
         # Do not run specs if the process is exiting on an error
@@ -288,7 +288,7 @@ module Spec
     end
 
     def finish_run
-      elapsed_time = Time.monotonic - @start_time.not_nil!
+      elapsed_time = Time.instant - @start_time.not_nil!
       root_context.finish(elapsed_time, @aborted)
       exit 1 if !root_context.succeeded || @aborted || (focus? && ENV["SPEC_FOCUS_NO_FAIL"]? != "1")
     end

--- a/src/stdlib/spec/example.cr
+++ b/src/stdlib/spec/example.cr
@@ -32,7 +32,7 @@ module Spec
         end
 
         non_nil_block = block
-        start = Time.monotonic
+        start = Time.instant
 
         ran = @parent.run_around_each_hooks(Example::Procsy.new(self) { internal_run(start, non_nil_block) })
         ran || internal_run(start, non_nil_block)
@@ -48,14 +48,14 @@ module Spec
     private def internal_run(start, block)
       @parent.run_before_each_hooks
       block.call
-      @parent.report(:success, description, file, line, Time.monotonic - start)
+      @parent.report(:success, description, file, line, Time.instant - start)
     rescue ex : Spec::AssertionFailed
-      @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
+      @parent.report(:fail, description, file, line, Time.instant - start, ex)
       @parent.cli.abort! if @parent.cli.fail_fast?
     rescue ex : Spec::ExamplePending
-      @parent.report(:pending, description, file, line, Time.monotonic - start)
+      @parent.report(:pending, description, file, line, Time.instant - start)
     rescue ex
-      @parent.report(:error, description, file, line, Time.monotonic - start, ex)
+      @parent.report(:error, description, file, line, Time.instant - start, ex)
       @parent.cli.abort! if @parent.cli.fail_fast?
     ensure
       @parent.run_after_each_hooks

--- a/src/stdlib/time.cr
+++ b/src/stdlib/time.cr
@@ -197,9 +197,9 @@ require "crystal/system/time"
 # A reading from this clock can be taken using `.monotonic`:
 #
 # ```
-# t1 = Time.monotonic
+# t1 = Time.instant
 # # operation that takes 1 minute
-# t2 = Time.monotonic
+# t2 = Time.instant
 # t2 - t1 # => 1.minute (approximately)
 # ```
 #
@@ -331,16 +331,16 @@ struct Time
   # both readings:
   #
   # ```
-  # start = Time.monotonic
+  # start = Time.instant
   # # operation that takes 20 milliseconds
-  # elapsed = Time.monotonic - start # => 20.milliseconds (approximately)
+  # elapsed = Time.instant - start # => 20.milliseconds (approximately)
   # # operation that takes 50 milliseconds
-  # elapsed_total = Time.monotonic - start # => 70.milliseconds (approximately)
+  # elapsed_total = Time.instant - start # => 70.milliseconds (approximately)
   # ```
   #
   # The execution time of a block can be measured using `.measure`.
   def self.monotonic : Time::Span
-    seconds, nanoseconds = Crystal::System::Time.monotonic
+    seconds, nanoseconds = Crystal::System::Time.instant
     Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
   end
 

--- a/src/stdlib_crystal/benchmark.cr
+++ b/src/stdlib_crystal/benchmark.cr
@@ -131,9 +131,9 @@ module Benchmark
 
   # Returns the time used to execute the given block.
   def measure(label = "", &) : BM::Tms
-    t0, r0 = Process.times, Time.monotonic
+    t0, r0 = Process.times, Time.instant
     yield
-    t1, r1 = Process.times, Time.monotonic
+    t1, r1 = Process.times, Time.instant
     BM::Tms.new(t1.utime - t0.utime,
       t1.stime - t0.stime,
       t1.cutime - t0.cutime,

--- a/src/stdlib_crystal/benchmark/ips.cr
+++ b/src/stdlib_crystal/benchmark/ips.cr
@@ -67,9 +67,9 @@ module Benchmark
 
           count = 0_u64
           elapsed = Time.measure do
-            target = Time.monotonic + @warmup_time
+            target = Time.instant + @warmup_time
 
-            while Time.monotonic < target
+            while Time.instant < target
               item.call
               count += 1
             end
@@ -87,7 +87,7 @@ module Benchmark
           bytes = 0_i64
           cycles = 0_i64
 
-          target = Time.monotonic + @calculation_time
+          target = Time.instant + @calculation_time
 
           loop do
             elapsed = nil
@@ -97,7 +97,7 @@ module Benchmark
             bytes += bytes_taken
             cycles += item.cycles
             measurements << elapsed.not_nil!
-            break if Time.monotonic >= target
+            break if Time.instant >= target
           end
 
           ips = measurements.map { |m| item.cycles.to_f / m.total_seconds }

--- a/src/stdlib_crystal/crystal/event_loop/iocp.cr
+++ b/src/stdlib_crystal/crystal/event_loop/iocp.cr
@@ -97,7 +97,7 @@ class Crystal::EventLoop::IOCP < Crystal::EventLoop
       if time = @mutex.synchronize { @timers.next_ready? }
         # convert absolute time of next timer to relative time, expressed in
         # milliseconds, rounded up
-        seconds, nanoseconds = System::Time.monotonic
+        seconds, nanoseconds = System::Time.instant
         relative = time - Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
         timeout = (relative.to_i * 1000 + (relative.nanoseconds + 999_999) // 1_000_000).clamp(0_i64..)
       else

--- a/src/stdlib_crystal/crystal/event_loop/iocp/fiber_event.cr
+++ b/src/stdlib_crystal/crystal/event_loop/iocp/fiber_event.cr
@@ -9,7 +9,7 @@ class Crystal::EventLoop::IOCP::FiberEvent
 
   # io timeout, sleep, or select timeout
   def add(timeout : Time::Span) : Nil
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     @timer.wake_at = now + timeout
     EventLoop.current.add_timer(pointerof(@timer))

--- a/src/stdlib_crystal/crystal/event_loop/iocp/timer.cr
+++ b/src/stdlib_crystal/crystal/event_loop/iocp/timer.cr
@@ -27,7 +27,7 @@ struct Crystal::EventLoop::IOCP::Timer
 
   def initialize(@type : Type, @fiber, timeout : Time::Span? = nil)
     if timeout
-      seconds, nanoseconds = System::Time.monotonic
+      seconds, nanoseconds = System::Time.instant
       now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
       @wake_at = now + timeout
     end

--- a/src/stdlib_crystal/crystal/event_loop/kqueue.cr
+++ b/src/stdlib_crystal/crystal/event_loop/kqueue.cr
@@ -216,7 +216,7 @@ class Crystal::EventLoop::Kqueue < Crystal::EventLoop::Polling
     if time
       flags = LibC::EV_ADD | LibC::EV_ONESHOT | LibC::EV_CLEAR
 
-      seconds, nanoseconds = System::Time.monotonic
+      seconds, nanoseconds = System::Time.instant
       now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
       t = time - now
 

--- a/src/stdlib_crystal/crystal/event_loop/polling/event.cr
+++ b/src/stdlib_crystal/crystal/event_loop/polling/event.cr
@@ -41,7 +41,7 @@ struct Crystal::EventLoop::Polling::Event
 
   def initialize(@type : Type, @fiber, @index = nil, timeout : Time::Span? = nil)
     if timeout
-      seconds, nanoseconds = System::Time.monotonic
+      seconds, nanoseconds = System::Time.instant
       now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
       @wake_at = now + timeout
     end

--- a/src/stdlib_crystal/crystal/event_loop/polling/fiber_event.cr
+++ b/src/stdlib_crystal/crystal/event_loop/polling/fiber_event.cr
@@ -7,7 +7,7 @@ class Crystal::EventLoop::Polling::FiberEvent
 
   # sleep or select timeout
   def add(timeout : Time::Span) : Nil
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     @event.wake_at = now + timeout
     EventLoop.current.add_timer(pointerof(@event))

--- a/src/stdlib_crystal/crystal/event_loop/timers.cr
+++ b/src/stdlib_crystal/crystal/event_loop/timers.cr
@@ -26,10 +26,10 @@ struct Crystal::EventLoop::Timers(T)
   end
 
   # Dequeues and yields each ready timer (their `#wake_at` is lower than
-  # `System::Time.monotonic`) from the oldest to the most recent (i.e. time
+  # `System::Time.instant`) from the oldest to the most recent (i.e. time
   # ascending).
   def dequeue_ready(& : Pointer(T) -> Nil) : Nil
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     now = Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
 
     while event = @heap.first?

--- a/src/stdlib_crystal/crystal/system/win32/waitable_timer.cr
+++ b/src/stdlib_crystal/crystal/system/win32/waitable_timer.cr
@@ -15,7 +15,7 @@ class Crystal::System::WaitableTimer
   def set(time : ::Time::Span) : Nil
     # convert absolute time to relative time, expressed in 100ns interval,
     # rounded up
-    seconds, nanoseconds = System::Time.monotonic
+    seconds, nanoseconds = System::Time.instant
     relative = time - ::Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
     ticks = (relative.to_i * 10_000_000 + (relative.nanoseconds + 99) // 100).clamp(0_i64..)
 

--- a/src/stdlib_crystal/fiber/execution_context/monitor.cr
+++ b/src/stdlib_crystal/fiber/execution_context/monitor.cr
@@ -47,9 +47,9 @@ module Fiber::ExecutionContext
 
       loop do
         Thread.sleep(remaining)
-        now = Time.monotonic
+        now = Time.instant
         yield(now)
-        remaining = (now + @every - Time.monotonic).clamp(Time::Span.zero..)
+        remaining = (now + @every - Time.instant).clamp(Time::Span.zero..)
       rescue exception
         Crystal.print_error_buffered("BUG: %s#every crashed", self.class.name, exception: exception)
       end

--- a/src/stdlib_crystal/http/server/handlers/log_handler.cr
+++ b/src/stdlib_crystal/http/server/handlers/log_handler.cr
@@ -11,12 +11,12 @@ class HTTP::LogHandler
   end
 
   def call(context : HTTP::Server::Context) : Nil
-    start = Time.monotonic
+    start = Time.instant
 
     begin
       call_next(context)
     ensure
-      elapsed = Time.monotonic - start
+      elapsed = Time.instant - start
       elapsed_text = elapsed_text(elapsed)
 
       req = context.request

--- a/src/stdlib_crystal/spec/dsl.cr
+++ b/src/stdlib_crystal/spec/dsl.cr
@@ -181,7 +181,7 @@ module Spec
     @start_time : Time::Span? = nil
 
     def run
-      @start_time = Time.monotonic
+      @start_time = Time.instant
 
       at_exit do |status|
         # Do not run specs if the process is exiting on an error
@@ -288,7 +288,7 @@ module Spec
     end
 
     def finish_run
-      elapsed_time = Time.monotonic - @start_time.not_nil!
+      elapsed_time = Time.instant - @start_time.not_nil!
       root_context.finish(elapsed_time, @aborted)
       exit 1 if !root_context.succeeded || @aborted || (focus? && ENV["SPEC_FOCUS_NO_FAIL"]? != "1")
     end

--- a/src/stdlib_crystal/spec/example.cr
+++ b/src/stdlib_crystal/spec/example.cr
@@ -32,7 +32,7 @@ module Spec
         end
 
         non_nil_block = block
-        start = Time.monotonic
+        start = Time.instant
 
         ran = @parent.run_around_each_hooks(Example::Procsy.new(self) { internal_run(start, non_nil_block) })
         ran || internal_run(start, non_nil_block)
@@ -48,14 +48,14 @@ module Spec
     private def internal_run(start, block)
       @parent.run_before_each_hooks
       block.call
-      @parent.report(:success, description, file, line, Time.monotonic - start)
+      @parent.report(:success, description, file, line, Time.instant - start)
     rescue ex : Spec::AssertionFailed
-      @parent.report(:fail, description, file, line, Time.monotonic - start, ex)
+      @parent.report(:fail, description, file, line, Time.instant - start, ex)
       @parent.cli.abort! if @parent.cli.fail_fast?
     rescue ex : Spec::ExamplePending
-      @parent.report(:pending, description, file, line, Time.monotonic - start)
+      @parent.report(:pending, description, file, line, Time.instant - start)
     rescue ex
-      @parent.report(:error, description, file, line, Time.monotonic - start, ex)
+      @parent.report(:error, description, file, line, Time.instant - start, ex)
       @parent.cli.abort! if @parent.cli.fail_fast?
     ensure
       @parent.run_after_each_hooks

--- a/src/stdlib_crystal/time.cr
+++ b/src/stdlib_crystal/time.cr
@@ -197,9 +197,9 @@ require "crystal/system/time"
 # A reading from this clock can be taken using `.monotonic`:
 #
 # ```
-# t1 = Time.monotonic
+# t1 = Time.instant
 # # operation that takes 1 minute
-# t2 = Time.monotonic
+# t2 = Time.instant
 # t2 - t1 # => 1.minute (approximately)
 # ```
 #
@@ -331,16 +331,16 @@ struct Time
   # both readings:
   #
   # ```
-  # start = Time.monotonic
+  # start = Time.instant
   # # operation that takes 20 milliseconds
-  # elapsed = Time.monotonic - start # => 20.milliseconds (approximately)
+  # elapsed = Time.instant - start # => 20.milliseconds (approximately)
   # # operation that takes 50 milliseconds
-  # elapsed_total = Time.monotonic - start # => 70.milliseconds (approximately)
+  # elapsed_total = Time.instant - start # => 70.milliseconds (approximately)
   # ```
   #
   # The execution time of a block can be measured using `.measure`.
   def self.monotonic : Time::Span
-    seconds, nanoseconds = Crystal::System::Time.monotonic
+    seconds, nanoseconds = Crystal::System::Time.instant
     Time::Span.new(seconds: seconds, nanoseconds: nanoseconds)
   end
 

--- a/tools/lsp_tests.py
+++ b/tools/lsp_tests.py
@@ -4,7 +4,7 @@ Lightweight LSP regression checks for the v2 server.
 Covers:
   - diagnostics: valid file => none; invalid file => at least one
   - hover: contains expected signature
-  - definition: resolves to stdlib symbol (Time.monotonic -> time.cr)
+  - definition: resolves to stdlib symbol (Time.instant -> time.cr)
 """
 import json
 import os
@@ -64,7 +64,7 @@ def run_tests() -> int:
         'require "time"\n'
         'require "json"\n'
         'require "option_parser"\n'
-        'start = Time.monotonic\n'
+        'start = Time.instant\n'
         'val = JSON.parse("{}")\n'
         'parser = OptionParser.new\n'
     )
@@ -153,7 +153,7 @@ def run_tests() -> int:
         proc.kill()
         return 1
 
-    # Hover test on Time.monotonic (line 4th line zero-based index 3, char ~14)
+    # Hover test on Time.instant (line 4th line zero-based index 3, char ~14)
     send(
         proc,
         {

--- a/tools/lsp_timing.cr
+++ b/tools/lsp_timing.cr
@@ -46,14 +46,14 @@ class LSPTimingProbe
 
     return nil if content_length == 0
 
-    t0 = Time.monotonic
+    t0 = Time.instant
     body = Bytes.new(content_length)
     @output.read_fully(body)
-    t1 = Time.monotonic
+    t1 = Time.instant
     str = String.new(body)
-    t2 = Time.monotonic
+    t2 = Time.instant
     result = JSON.parse(str)
-    t3 = Time.monotonic
+    t3 = Time.instant
 
     if content_length > 100_000
       STDERR.puts "  [PROBE] large response: #{content_length} bytes, read=#{(t1-t0).total_milliseconds.round(1)}ms, string=#{(t2-t1).total_milliseconds.round(1)}ms, parse=#{(t3-t2).total_milliseconds.round(1)}ms"
@@ -65,9 +65,9 @@ class LSPTimingProbe
   def wait_for_response(id : Int32, debug = false) : JSON::Any?
     msg_count = 0
     loop do
-      t0 = Time.monotonic
+      t0 = Time.instant
       msg = read_message
-      t1 = Time.monotonic
+      t1 = Time.instant
       return nil unless msg
       msg_count += 1
 
@@ -95,9 +95,9 @@ class LSPTimingProbe
   end
 
   def timed(label : String, &)
-    start = Time.monotonic
+    start = Time.instant
     result = yield
-    elapsed = Time.monotonic - start
+    elapsed = Time.instant - start
     @timings << {label, elapsed}
     puts "  #{label}: #{format_time(elapsed)}"
     result

--- a/tools/scan_parser.cr
+++ b/tools/scan_parser.cr
@@ -27,12 +27,12 @@ end
 files = Dir.glob("#{__DIR__}/../src/**/*.cr").sort
 max_files = ENV["SCAN_MAX_FILES"]?.try(&.to_i)
 max_duration = ENV["SCAN_MAX_DURATION"]?.try(&.to_f)
-start_time = Time.monotonic
+start_time = Time.instant
 processed = 0
 
 files.each_with_index do |file, idx|
   break if max_files && processed >= max_files
-  break if max_duration && (Time.monotonic - start_time) > max_duration.seconds
+  break if max_duration && (Time.instant - start_time) > max_duration.seconds
   puts "[#{idx}] start #{file}"
   STDOUT.flush
   begin


### PR DESCRIPTION
Use Time.instant instead of deprecated Time.monotonic

Mostly search + replace to be able to build compiler with Crystal 1.19.0
I haven't tested anything else, so feel free to just close this PR ;)

See:

Deprecate Time.monotonic
https://github.com/crystal-lang/crystal/pull/16545

Other related PRs
https://github.com/crystal-lang/crystal/pull/16490
https://github.com/crystal-lang/crystal/pull/16498
https://github.com/crystal-lang/crystal/pull/16506
https://github.com/crystal-lang/crystal/pull/16516
https://github.com/crystal-lang/crystal/pull/16500

Not sure about changes to `src/stdlib/**` - you'd probably want to sync from crystal repo?